### PR TITLE
Add support for CLI arguments

### DIFF
--- a/com.nicoohagedorn.pythonscriptdeck.sdPlugin/ui/python-script.html
+++ b/com.nicoohagedorn.pythonscriptdeck.sdPlugin/ui/python-script.html
@@ -76,6 +76,9 @@
     <sdpi-item label="Path to Script">
         <sdpi-file setting="path" accept="text/py"></sdpi-file>
     </sdpi-item>
+    <sdpi-item label="CLI Arguments">
+        <sdpi-textfield setting="cliArgs"></sdpi-textfield>
+    </sdpi-item>
     <sdpi-item label="display Values?">
         <sdpi-checkbox setting="displayValues" label="Yes / No?"></sdpi-checkbox>
     </sdpi-item>

--- a/com.nicoohagedorn.pythonscriptdeck.sdPlugin/ui/python-service.html
+++ b/com.nicoohagedorn.pythonscriptdeck.sdPlugin/ui/python-service.html
@@ -14,6 +14,9 @@
     <sdpi-item label="Path to Script">
         <sdpi-file setting="path" accept="text/py"></sdpi-file>
     </sdpi-item>
+    <sdpi-item label="CLI Arguments">
+        <sdpi-textfield setting="cliArgs"></sdpi-textfield>
+    </sdpi-item>
     <sdpi-item label="Checkbox">
         <sdpi-checkbox setting="displayValues" label="display the values?"></sdpi-checkbox>
     </sdpi-item>

--- a/src/actions/python-script.ts
+++ b/src/actions/python-script.ts
@@ -89,7 +89,7 @@ export class PythonScript extends SingletonAction<PythonScriptSettings> {
 		let pythonProcess: ChildProcess | undefined;
 		if (path) {
 			streamDeck.logger.info(`path to script is: ${path}`)
-			pythonProcess = this.createChildProcess(settings.useVenv, settings.venvPath, path);
+			pythonProcess = this.createChildProcess(settings.useVenv, settings.venvPath, path, settings.cliArgs);
 
 			if (pythonProcess != undefined && pythonProcess.stdout != null) {
 				streamDeck.logger.info(`start reading output`);
@@ -135,17 +135,18 @@ export class PythonScript extends SingletonAction<PythonScriptSettings> {
 
 	}
 
-	createChildProcess(useVenv: boolean, venvPath: string | undefined, path: string) {
+	createChildProcess(useVenv: boolean, venvPath: string | undefined, path: string, cliArgs: string | undefined) {
 		let pythonProcess: ChildProcess | undefined;
+		const args = cliArgs || "";
 		if (useVenv && venvPath) {
 			
 			streamDeck.logger.info(`Use Virtual Environment: ${venvPath}`)
-			pythonProcess = spawn("cmd.exe", ["/c", `call ${venvPath.substring(0, venvPath.lastIndexOf("/"))}/Scripts/activate.bat && python ${path}`]);
+			pythonProcess = spawn("cmd.exe", ["/c", `call ${venvPath.substring(0, venvPath.lastIndexOf("/"))}/Scripts/activate.bat && python ${path} ${args}`]);
 
 		}
 		else {
 			streamDeck.logger.info(`Use Python: ${path}`)
-			pythonProcess = spawn(`cmd.exe`, [`/c ${path}`]);
+			pythonProcess = spawn(`cmd.exe`, [`/c ${path} ${args}`]);
 			/*
 			if (pythonProcess.connected == false) {
 				streamDeck.logger.debug("python not found, trying python3")
@@ -169,6 +170,7 @@ export class PythonScript extends SingletonAction<PythonScriptSettings> {
  */
 export type PythonScriptSettings = {
 	path?: string;
+	cliArgs?: string;
 	value1?: string;
 	image1?: string;
 	value2?: string;

--- a/src/actions/python-service.ts
+++ b/src/actions/python-service.ts
@@ -97,6 +97,7 @@ export class PythonService extends SingletonAction<PythonServiceSettings> {
  */
 export type PythonServiceSettings = {
 	path?: string;
+	cliArgs?: string;
 	value1?: string;
 	image1?: string;
 	value2?: string;

--- a/src/python-bg-service.ts
+++ b/src/python-bg-service.ts
@@ -107,7 +107,7 @@ class PythonBackgroundService {
 		let pythonProcess: ChildProcess | undefined;
 		if (path) {
 			streamDeck.logger.debug(`path to script is: ${path}`)
-			pythonProcess = this.createChildProcess(settings.useVenv, settings.venvPath, path);
+			pythonProcess = this.createChildProcess(settings.useVenv, settings.venvPath, path, settings.cliArgs);
 
 			if (pythonProcess != undefined && pythonProcess.stdout != null) {
 				streamDeck.logger.debug(`start reading output`);
@@ -151,23 +151,24 @@ class PythonBackgroundService {
 		}
 
 	}
-	createChildProcess(useVenv: boolean, venvPath: string | undefined, path: string) {
+	createChildProcess(useVenv: boolean, venvPath: string | undefined, path: string, cliArgs: string | undefined) {
 		let pythonProcess: ChildProcess | undefined;
+		const args = cliArgs || "";
 		const isWindows = os.platform() === "win32";
 
 		if (useVenv && venvPath) {
 			if (isWindows) {
 				// Windows - use .bat activation
-				pythonProcess = spawn("cmd.exe", ["/c", `call ${venvPath}/Scripts/activate.bat && python ${path}`]);
+				pythonProcess = spawn("cmd.exe", ["/c", `call ${venvPath}/Scripts/activate.bat && python ${path} ${args}`]);
 			} else {
 				// macOS/Linux - use source and run in bash
-				pythonProcess = spawn("bash", ["-c", `source "${venvPath}/bin/activate" && python3 "${path}"`]);
+				pythonProcess = spawn("bash", ["-c", `source "${venvPath}/bin/activate" && python3 "${path}" ${args}`]);
 			}
 		} else {
 			if (isWindows) {
-				pythonProcess = spawn("cmd.exe", ["/c", `python ${path}`]);
+				pythonProcess = spawn("cmd.exe", ["/c", `python ${path} ${args}`]);
 			} else {
-				pythonProcess = spawn("python3", [path]);
+				pythonProcess = spawn("python3", [path, ...args.split(" ")]);
 			}
 		}
 		


### PR DESCRIPTION
Allows defining CLI arguments that can be later parsed in Python script. This enables creating a single script with several similar actions based on the passed arguments.

Closes #17 